### PR TITLE
skip DNSDumpster when no API key is set

### DIFF
--- a/cloudfail.py
+++ b/cloudfail.py
@@ -87,6 +87,9 @@ def dnsdumpster(target):
     
     res = DNSDumpsterAPI(False).search(target)
 
+    if not res:
+        return
+
     if res['dns_records']['host']:
         for entry in res['dns_records']['host']:
             provider = str(entry['provider'])


### PR DESCRIPTION
Thank you so much for forking the base project and fixing the DNSDumpster problem!
I suggest a tiny improvement: Don't fail, if no DNSDumpster API key is set, but rather skip it.

Cheers! :)