### PR TITLE
Tor: Fix public IP server error

### DIFF
--- a/cloudfail.py
+++ b/cloudfail.py
@@ -298,7 +298,7 @@ parser.set_defaults(update=False)
 args = parser.parse_args()
 
 if args.tor is True:
-    ipcheck_url = 'http://ipinfo.io/ip'
+    ipcheck_url = 'https://api.ipify.org/'
     socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, '127.0.0.1', 9050)
     socket.socket = socks.socksocket
     try:

--- a/cloudfail.py
+++ b/cloudfail.py
@@ -302,11 +302,14 @@ if args.tor is True:
     socks.setdefaultproxy(socks.PROXY_TYPE_SOCKS5, '127.0.0.1', 9050)
     socket.socket = socks.socksocket
     try:
-        tor_ip = requests.get(ipcheck_url)
-        tor_ip = str(tor_ip.text)
+        resp = requests.get(ipcheck_url)
+        if resp.status_code == 200:
+            tor_ip = str(resp.text)
+        else:
+            tor_ip = "unknown"
 
         print_out(Fore.WHITE + Style.BRIGHT + "TOR connection established!")
-        print_out(Fore.WHITE + Style.BRIGHT + "New IP: " + tor_ip)
+        print_out(Fore.WHITE + Style.BRIGHT + "IP in use: " + tor_ip)
 
     except requests.exceptions.RequestException as e:
         print(e, net_exc)


### PR DESCRIPTION
When using the `--tor` option, I get this awkward output from Cloudfail:

```
   ____ _                 _ _____     _ _
  / ___| | ___  _   _  __| |  ___|_ _(_) |
 | |   | |/ _ \| | | |/ _` | |_ / _` | | |
 | |___| | (_) | |_| | (_| |  _| (_| | | |
  \____|_|\___/ \__,_|\__,_|_|  \__,_|_|_|
    v1.0.6                      by m0rtem / updated by cnoid


[18:07:02] Initializing CloudFail - the date is: 22/01/2025
[18:07:05] TOR connection established!
[18:07:05] New IP:
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>403 Forbidden</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Forbidden</h1>
<h2>Your client does not have permission to get URL <code>/ip</code> from this server.</h2>
<h2></h2>
</body></html>
...
```

When using the `--tor` option, the public IP as seen by the target should be printed. However, the API being used for that seems to block most Tor exit nodes.

This pull request tries to fix this issue by changing two things:
1. Use another API service, which seems to work with Tor exit nodes
2. Check the HTTP response code and print `unknown` instead, when there was an error