### PR TITLE
Update requirements to latest minor/patch versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-beautifulsoup4==4.6.0
-bs4==0.0.1
-certifi==2017.4.17
+beautifulsoup4==4.13.3
+bs4==0.0.2
+certifi==2025.1.31
 chardet==3.0.4
-colorama==0.3.9
+colorama==0.4.6
 idna==2.5
 requests>=2.20.0
-urllib3==1.24.2
-win_inet_pton==1.0.1
+urllib3==1.26.20
+win_inet_pton==1.1.0
 dnspython==1.15.0
 python-dotenv==1.0.1


### PR DESCRIPTION
I switched to Python 3.12 and am now getting following error, when running the tool:

```
(.venv) $:~/CloudFail$ python3 cloudfail.py -h
Traceback (most recent call last):
  File "/CloudFail/cloudfail.py", line 10, in <module>
    import requests
  File "/.venv/lib/python3.12/site-packages/requests/__init__.py", line 43, in <module>
    import urllib3
  File "/.venv/lib/python3.12/site-packages/urllib3/__init__.py", line 8, in <module>
    from .connectionpool import (
  File "/.venv/lib/python3.12/site-packages/urllib3/connectionpool.py", line 11, in <module>
    from .exceptions import (
  File "/.venv/lib/python3.12/site-packages/urllib3/exceptions.py", line 2, in <module>
    from .packages.six.moves.http_client import (
ModuleNotFoundError: No module named 'urllib3.packages.six.moves'
```

`urllib3.packages.six.moves` is part of the `urrlib3` requirement, defined in `requirements.txt`. But the version is quite old and not compatible with Python 3.12 any more. By upgrading to `1.26.20` (the latest `1.x` release), this can be fixed easily.

I took the liberty, and updated all requirements to their latest minor or patch release update, as some versions were quite outdated.

I successfully tested the change to be compatible with Python 3.12, as well as 3.10.